### PR TITLE
Feature/be1

### DIFF
--- a/src/main/java/com/example/hyu/assistant/AssistantClient.java
+++ b/src/main/java/com/example/hyu/assistant/AssistantClient.java
@@ -1,0 +1,15 @@
+package com.example.hyu.assistant;
+
+import com.example.hyu.dto.chat.MessageDto;
+
+import java.util.List;
+
+public interface AssistantClient {
+    /**
+     * @param systemPrompt 세션의 시스템 프롬프트(프로필 기반)
+     * @param history      최근 대화(필요 시 일부만 전달)
+     * @param userMessage  사용자의 최신 입력
+     * @return             어시스턴트의 응답 텍스트
+     */
+    String reply(String systemPrompt, List<MessageDto> history, String userMessage);
+}

--- a/src/main/java/com/example/hyu/assistant/DummyAssistantClient.java
+++ b/src/main/java/com/example/hyu/assistant/DummyAssistantClient.java
@@ -1,0 +1,26 @@
+package com.example.hyu.assistant;
+
+import com.example.hyu.dto.chat.MessageDto;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DummyAssistantClient implements AssistantClient {
+
+    @Override
+    public String reply(String systemPrompt, List<MessageDto> history, String userMessage) {
+        // 아주 단순한 룰/템플릿 기반 응답 (향후 LLM으로 교체)
+        String msg = userMessage == null ? "" : userMessage.trim();
+
+        if (msg.isBlank()) return "무슨 생각이 드셨는지 한두 문장으로 적어주실래요?";
+        if (msg.contains("안녕") || msg.contains("안녕하세요"))
+            return "안녕하세요! 오늘 기분은 어떠세요? 편하게 말씀해 주세요.";
+
+        if (msg.length() < 8)
+            return "조금만 더 자세히 들려주실 수 있을까요? 어떤 상황이었는지도 함께 알려주세요.";
+
+        return "말해 주셔서 고마워요. 말씀하신 내용을 보니 꽤 신경 쓰이는 일이었겠어요. "
+                + "그 상황에서 특히 힘들었던 점 한 가지를 꼽는다면 무엇일까요?";
+    }
+}

--- a/src/main/java/com/example/hyu/config/SchedulingConfig.java
+++ b/src/main/java/com/example/hyu/config/SchedulingConfig.java
@@ -1,0 +1,8 @@
+package com.example.hyu.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {}

--- a/src/main/java/com/example/hyu/config/SecurityConfig.java
+++ b/src/main/java/com/example/hyu/config/SecurityConfig.java
@@ -74,7 +74,7 @@ class SecurityConfig {
                             "/api/contents/**",
                             "/auth-test.html", "/jwt-check.html",
                             "/static/**", "/favicon.ico",
-                            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/checkins/**",
+                            "/v3/api-docs/**", "/swagger-ui/**", "/sessions/**","/swagger-ui.html", "/checkins/**",
                             "/api/public/password-reset/**"
                     ).permitAll();
 

--- a/src/main/java/com/example/hyu/config/SecurityConfig.java
+++ b/src/main/java/com/example/hyu/config/SecurityConfig.java
@@ -74,7 +74,7 @@ class SecurityConfig {
                             "/api/contents/**",
                             "/auth-test.html", "/jwt-check.html",
                             "/static/**", "/favicon.ico",
-                            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
+                            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/checkins/**",
                             "/api/public/password-reset/**"
                     ).permitAll();
 

--- a/src/main/java/com/example/hyu/controller/chat/ChatController.java
+++ b/src/main/java/com/example/hyu/controller/chat/ChatController.java
@@ -1,0 +1,54 @@
+package com.example.hyu.controller.chat;
+
+
+import com.example.hyu.dto.chat.CreateSessionResponse;
+import com.example.hyu.dto.chat.MessageDto;
+import com.example.hyu.dto.chat.SendMessageRequest;
+import com.example.hyu.dto.chat.SessionDto;
+import com.example.hyu.security.AuthPrincipal;
+import com.example.hyu.service.chat.ChatService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sessions")
+@PreAuthorize("hasAnyRole('USER','ADMIN')")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping
+    public CreateSessionResponse create(@AuthenticationPrincipal AuthPrincipal me) {
+        return chatService.create(me.getUserId());
+    }
+
+    @GetMapping
+    public Page<SessionDto> list(@AuthenticationPrincipal AuthPrincipal me,
+                                 @RequestParam(defaultValue = "0") int page,
+                                 @RequestParam(defaultValue = "20") int size) {
+        return chatService.list(me.getUserId(), PageRequest.of(page, size));
+    }
+
+    @GetMapping("/{id}/messages")
+    public Page<MessageDto> messages(@AuthenticationPrincipal AuthPrincipal me,
+                                     @PathVariable UUID id,
+                                     @RequestParam(defaultValue = "0") int page,
+                                     @RequestParam(defaultValue = "50") int size) {
+        return chatService.getMessages(me.getUserId(), id, PageRequest.of(page, size));
+    }
+
+    @PostMapping("/{id}/messages")
+    public MessageDto send(@AuthenticationPrincipal AuthPrincipal me,
+                           @PathVariable UUID id,
+                           @Valid @RequestBody SendMessageRequest req) {
+        return chatService.send(me.getUserId(), id, req.content());
+    }
+}

--- a/src/main/java/com/example/hyu/controller/checkin/CheckinController.java
+++ b/src/main/java/com/example/hyu/controller/checkin/CheckinController.java
@@ -1,0 +1,62 @@
+package com.example.hyu.controller.checkin;
+
+import com.example.hyu.dto.checkin.CheckinCreateResponse;
+import com.example.hyu.dto.checkin.CheckinStatsResponse;
+import com.example.hyu.dto.checkin.CheckinTodayResponse;
+import com.example.hyu.security.AuthPrincipal;
+import com.example.hyu.service.checkin.CheckinService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/checkins")
+@PreAuthorize("hasAnyRole('USER','ADMIN')")
+public class CheckinController {
+
+    private final CheckinService checkinService;
+
+    /** 로그인 직후: 오늘 체크 여부 + 모달 띄울지 */
+    @GetMapping("/today")
+    public CheckinTodayResponse today(@AuthenticationPrincipal AuthPrincipal me) {
+        return checkinService.getToday(me.getUserId());
+    }
+
+    /** 출석체크(같은 날 여러번 호출해도 안전) */
+    @PostMapping
+    public CheckinCreateResponse create(@AuthenticationPrincipal AuthPrincipal me) {
+        return checkinService.checkinToday(me.getUserId());
+    }
+
+    /** 임의 기간 통계 */
+    @GetMapping("/stats")
+    public CheckinStatsResponse stats(
+            @AuthenticationPrincipal AuthPrincipal me,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        return checkinService.getStats(me.getUserId(), from, to);
+    }
+
+    /** 월 단위 통계(프로필에서 이번 달 요약 표시용) */
+    @GetMapping("/stats/month")
+    public CheckinStatsResponse monthStats(
+            @AuthenticationPrincipal AuthPrincipal me,
+            @RequestParam(required = false) String month // "YYYY-MM", 없으면 이번 달
+    ) {
+        ZoneId ZONE = ZoneId.of("Asia/Seoul");
+        YearMonth ym = (month == null || month.isBlank())
+                ? YearMonth.from(LocalDate.now(ZONE))
+                : YearMonth.parse(month);
+        LocalDate start = ym.atDay(1);
+        LocalDate end   = ym.atEndOfMonth();
+        return checkinService.getStats(me.getUserId(), start, end);
+    }
+}

--- a/src/main/java/com/example/hyu/dto/chat/CreateSessionResponse.java
+++ b/src/main/java/com/example/hyu/dto/chat/CreateSessionResponse.java
@@ -1,0 +1,5 @@
+package com.example.hyu.dto.chat;
+
+import java.util.UUID;
+
+public record CreateSessionResponse(UUID sessionId) {}

--- a/src/main/java/com/example/hyu/dto/chat/MessageDto.java
+++ b/src/main/java/com/example/hyu/dto/chat/MessageDto.java
@@ -1,0 +1,10 @@
+package com.example.hyu.dto.chat;
+
+import java.time.Instant;
+
+public record MessageDto(
+        Long id,
+        String role,     // USER / ASSISTANT / SYSTEM
+        String content,
+        Instant createdAt
+) {}

--- a/src/main/java/com/example/hyu/dto/chat/SendMessageRequest.java
+++ b/src/main/java/com/example/hyu/dto/chat/SendMessageRequest.java
@@ -1,0 +1,7 @@
+package com.example.hyu.dto.chat;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SendMessageRequest(
+        @NotBlank String content
+) {}

--- a/src/main/java/com/example/hyu/dto/chat/SessionDto.java
+++ b/src/main/java/com/example/hyu/dto/chat/SessionDto.java
@@ -1,0 +1,10 @@
+package com.example.hyu.dto.chat;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SessionDto(
+        UUID id,
+        String status,   // OPEN / CLOSED
+        Instant updatedAt
+) {}

--- a/src/main/java/com/example/hyu/dto/checkin/CheckinCreateResponse.java
+++ b/src/main/java/com/example/hyu/dto/checkin/CheckinCreateResponse.java
@@ -1,0 +1,9 @@
+package com.example.hyu.dto.checkin;
+
+import java.time.LocalDate;
+
+public record CheckinCreateResponse(
+        boolean created,  // 새로 생성했는지(이미 있으면 false)
+        LocalDate date,
+        int streak
+) {}

--- a/src/main/java/com/example/hyu/dto/checkin/CheckinStatsResponse.java
+++ b/src/main/java/com/example/hyu/dto/checkin/CheckinStatsResponse.java
@@ -1,0 +1,11 @@
+package com.example.hyu.dto.checkin;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+public record CheckinStatsResponse(
+        int streak,
+        int totalDays,
+        int checkedDays,
+        Map<LocalDate, Boolean> days // 날짜별 체크 여부(연속 달력 만들기 쉬움)
+) {}

--- a/src/main/java/com/example/hyu/dto/checkin/CheckinTodayResponse.java
+++ b/src/main/java/com/example/hyu/dto/checkin/CheckinTodayResponse.java
@@ -1,0 +1,10 @@
+package com.example.hyu.dto.checkin;
+
+import java.time.LocalDate;
+
+public record CheckinTodayResponse(
+        boolean checked,       // 오늘 체크인 여부
+        boolean shouldPrompt,  // 로그인 직후 모달/페이지 안내 여부
+        LocalDate date,        // 오늘 날짜(KST)
+        int streak             // 현재 연속 출석(오늘 포함)
+) {}

--- a/src/main/java/com/example/hyu/entity/ChatMessage.java
+++ b/src/main/java/com/example/hyu/entity/ChatMessage.java
@@ -1,0 +1,48 @@
+package com.example.hyu.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "chat_messages",
+        indexes = { @Index(name = "idx_msg_session_created", columnList = "session_id, createdAt") }
+)
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 세션 */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private ChatSession session;
+
+    /** 소유자(세션의 사용자 캐시; 접근 제어용) */
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private Role role; // USER, ASSISTANT, SYSTEM
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "text")
+    @Comment("메시지 내용")
+    private String content;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    public enum Role { USER, ASSISTANT, SYSTEM }
+
+    @PrePersist
+    void onCreate() {
+        this.createdAt = Instant.now();
+    }
+}

--- a/src/main/java/com/example/hyu/entity/ChatSession.java
+++ b/src/main/java/com/example/hyu/entity/ChatSession.java
@@ -1,0 +1,47 @@
+package com.example.hyu.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "chat_sessions")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ChatSession {
+
+    @Id
+    @GeneratedValue
+    @Comment("세션 ID (UUID)")
+    private UUID id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private Status status; // OPEN, CLOSED
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    public enum Status { OPEN, CLOSED }
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.status == null) this.status = Status.OPEN;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/example/hyu/entity/Checkin.java
+++ b/src/main/java/com/example/hyu/entity/Checkin.java
@@ -1,0 +1,26 @@
+package com.example.hyu.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.*;
+
+@Entity
+@Table(name = "checkins",
+        uniqueConstraints = @UniqueConstraint(name="uk_checkins_user_date", columnNames = {"user_id","date"}))
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Checkin {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="user_id", nullable=false)
+    private Long userId;
+
+    /** 사용자 기준(KST) 날짜 */
+    @Column(nullable=false)
+    private LocalDate date;
+
+    @Column(nullable=false)
+    private Instant createdAt;
+}

--- a/src/main/java/com/example/hyu/entity/WeeklySummary.java
+++ b/src/main/java/com/example/hyu/entity/WeeklySummary.java
@@ -1,0 +1,33 @@
+package com.example.hyu.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.*;
+
+@Entity
+@Table(name = "weekly_summaries",
+        uniqueConstraints = @UniqueConstraint(name="uk_weekly_summary_user_week", columnNames = {"user_id","week_start"}))
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class WeeklySummary {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="user_id", nullable=false)
+    private Long userId;
+
+    /** 주간 구간(월~일) */
+    @Column(name="week_start", nullable=false)
+    private LocalDate weekStart;
+
+    @Column(name="week_end", nullable=false)
+    private LocalDate weekEnd;
+
+    @Lob
+    @Column(columnDefinition = "text")
+    private String content;
+
+    @Column(nullable=false)
+    private Instant createdAt;
+}

--- a/src/main/java/com/example/hyu/notification/LoggingNotificationSender.java
+++ b/src/main/java/com/example/hyu/notification/LoggingNotificationSender.java
@@ -1,0 +1,13 @@
+package com.example.hyu.notification;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class LoggingNotificationSender implements NotificationSender {
+    @Override
+    public void sendInApp(Long userId, String title, String body) {
+        log.info("[IN-APP] userId={} | {} - {}", userId, title, body);
+    }
+}

--- a/src/main/java/com/example/hyu/notification/NotificationSender.java
+++ b/src/main/java/com/example/hyu/notification/NotificationSender.java
@@ -1,0 +1,6 @@
+package com.example.hyu.notification;
+
+public interface NotificationSender {
+    void sendInApp(Long userId, String title, String body);
+    default void sendEmail(Long userId, String subject, String body) { /* no-op */ }
+}

--- a/src/main/java/com/example/hyu/repository/CheckinRepository.java
+++ b/src/main/java/com/example/hyu/repository/CheckinRepository.java
@@ -1,0 +1,14 @@
+package com.example.hyu.repository;
+
+import com.example.hyu.entity.Checkin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CheckinRepository extends JpaRepository<Checkin, Long> {
+    boolean existsByUserIdAndDate(Long userId, LocalDate date);
+    Optional<Checkin> findByUserIdAndDate(Long userId, LocalDate date);
+    List<Checkin> findAllByUserIdAndDateBetweenOrderByDateAsc(Long userId, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/example/hyu/repository/WeeklySummaryRepository.java
+++ b/src/main/java/com/example/hyu/repository/WeeklySummaryRepository.java
@@ -1,0 +1,10 @@
+package com.example.hyu.repository;
+
+import com.example.hyu.entity.WeeklySummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface WeeklySummaryRepository extends JpaRepository<WeeklySummary, Long> {
+    boolean existsByUserIdAndWeekStart(Long userId, LocalDate weekStart);
+}

--- a/src/main/java/com/example/hyu/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/example/hyu/repository/chat/ChatMessageRepository.java
@@ -1,0 +1,13 @@
+package com.example.hyu.repository.chat;
+
+import com.example.hyu.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    Page<ChatMessage> findBySession_IdAndUserIdOrderByCreatedAtAsc(UUID sessionId, Long userId, Pageable pageable);
+    boolean existsBySession_IdAndUserId(UUID sessionId, Long userId);
+}

--- a/src/main/java/com/example/hyu/repository/chat/ChatSessionRepository.java
+++ b/src/main/java/com/example/hyu/repository/chat/ChatSessionRepository.java
@@ -1,0 +1,12 @@
+package com.example.hyu.repository.chat;
+
+import com.example.hyu.entity.ChatSession;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ChatSessionRepository extends JpaRepository<ChatSession, UUID> {
+    Page<ChatSession> findByUserIdOrderByUpdatedAtDesc(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/hyu/scheduler/WeeklySummaryScheduler.java
+++ b/src/main/java/com/example/hyu/scheduler/WeeklySummaryScheduler.java
@@ -1,0 +1,69 @@
+package com.example.hyu.scheduler;
+
+import com.example.hyu.entity.Profile;
+import com.example.hyu.entity.WeeklySummary;
+import com.example.hyu.notification.NotificationSender;
+import com.example.hyu.repository.CheckinRepository;
+import com.example.hyu.repository.ProfileRepository;
+import com.example.hyu.repository.WeeklySummaryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.*;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WeeklySummaryScheduler {
+
+    private final ProfileRepository profileRepo;
+    private final CheckinRepository checkinRepo;
+    private final WeeklySummaryRepository weeklyRepo;
+    private final NotificationSender notifier;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    /** 매주 월요일 09:00 KST에 지난 주 요약 생성/전송 */
+    @Scheduled(cron = "0 0 9 * * MON", zone = "Asia/Seoul")
+    public void run() {
+        LocalDate today = LocalDate.now(ZONE);
+        LocalDate weekStart = today.minusWeeks(1).with(DayOfWeek.MONDAY);
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        List<Profile> targets = profileRepo.findAll().stream()
+                .filter(Profile::isWeeklySummary) // 주간 요약 수신 동의
+                .toList();
+
+        for (Profile p : targets) {
+            Long userId = p.getUserId();
+            try {
+                if (weeklyRepo.existsByUserIdAndWeekStart(userId, weekStart)) {
+                    continue; // 이미 발송됨
+                }
+                int checkedDays = checkinRepo
+                        .findAllByUserIdAndDateBetweenOrderByDateAsc(userId, weekStart, weekEnd)
+                        .size();
+
+                String content = String.format(
+                        "지난주 출석: %d/7일. 계속 화이팅이에요! (%s ~ %s)",
+                        checkedDays, weekStart, weekEnd
+                );
+
+                weeklyRepo.save(WeeklySummary.builder()
+                        .userId(userId)
+                        .weekStart(weekStart)
+                        .weekEnd(weekEnd)
+                        .content(content)
+                        .createdAt(Instant.now())
+                        .build());
+
+                notifier.sendInApp(userId, "주간 요약", content);
+            } catch (Exception e) {
+                log.warn("WeeklySummary fail userId={} weekStart={}: {}", userId, weekStart, e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/hyu/service/chat/ChatService.java
+++ b/src/main/java/com/example/hyu/service/chat/ChatService.java
@@ -1,0 +1,16 @@
+package com.example.hyu.service.chat;
+
+import com.example.hyu.dto.chat.CreateSessionResponse;
+import com.example.hyu.dto.chat.MessageDto;
+import com.example.hyu.dto.chat.SessionDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface ChatService {
+    CreateSessionResponse create(Long userId);
+    Page<SessionDto> list(Long userId, Pageable pageable);
+    Page<MessageDto> getMessages(Long userId, UUID sessionId, Pageable pageable);
+    MessageDto send(Long userId, UUID sessionId, String userContent);
+}

--- a/src/main/java/com/example/hyu/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/example/hyu/service/chat/ChatServiceImpl.java
@@ -1,0 +1,159 @@
+package com.example.hyu.service.chat;
+
+import com.example.hyu.assistant.AssistantClient;
+import com.example.hyu.dto.chat.CreateSessionResponse;
+import com.example.hyu.dto.chat.MessageDto;
+import com.example.hyu.dto.chat.SessionDto;
+import com.example.hyu.entity.ChatMessage;
+import com.example.hyu.entity.ChatSession;
+import com.example.hyu.entity.Profile;
+import com.example.hyu.repository.chat.ChatMessageRepository;
+import com.example.hyu.repository.chat.ChatSessionRepository;
+import com.example.hyu.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final ChatSessionRepository sessions;
+    private final ChatMessageRepository messages;
+    private final AssistantClient assistant;
+    private final ProfileRepository profiles;
+
+    @Override
+    @Transactional
+    public CreateSessionResponse create(Long userId) {
+        // 1) 세션 생성
+        ChatSession s = ChatSession.builder()
+                .userId(userId)
+                .status(ChatSession.Status.OPEN)
+                .build();
+        sessions.save(s); // @PrePersist 로 createdAt/updatedAt 세팅
+
+        // 2) 초기 SYSTEM 메시지(프로필 기반 프롬프트) 저장
+        ChatMessage sys = ChatMessage.builder()
+                .session(s)
+                .userId(userId)
+                .role(ChatMessage.Role.SYSTEM)
+                .content(buildSystemPrompt(userId))
+                .build();
+        messages.save(sys);
+
+        return new CreateSessionResponse(s.getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<SessionDto> list(Long userId, Pageable pageable) {
+        return sessions.findByUserIdOrderByUpdatedAtDesc(userId, pageable)
+                .map(s -> new SessionDto(s.getId(), s.getStatus().name(), s.getUpdatedAt()));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<MessageDto> getMessages(Long userId, UUID sessionId, Pageable pageable) {
+        ensureOwnership(userId, sessionId);
+        return messages
+                .findBySession_IdAndUserIdOrderByCreatedAtAsc(sessionId, userId, pageable)
+                .map(m -> new MessageDto(
+                        m.getId(),
+                        m.getRole().name(),
+                        m.getContent(),
+                        m.getCreatedAt()
+                ));
+    }
+
+    @Override
+    @Transactional
+    public MessageDto send(Long userId, UUID sessionId, String userContent) {
+        ChatSession s = ensureOwnership(userId, sessionId);
+
+        // 1) 사용자 메시지 저장
+        ChatMessage userMsg = messages.save(ChatMessage.builder()
+                .session(s)
+                .userId(userId)
+                .role(ChatMessage.Role.USER)
+                .content(userContent)
+                .build());
+
+        // 2) (선택) Safety 훅 자리
+        // SafetyResult sr = safetyService.check(userContent, profile.getCrisisResourcesRegion());
+        // if (sr.level()==CRITICAL) { ... }
+
+        // 3) 어시스턴트 응답 생성 (더미 어댑터 사용)
+        List<MessageDto> recent = messages
+                .findBySession_IdAndUserIdOrderByCreatedAtAsc(sessionId, userId, PageRequest.of(0, 50))
+                .map(m -> new MessageDto(m.getId(), m.getRole().name(), m.getContent(), m.getCreatedAt()))
+                .getContent();
+
+        String systemPrompt = loadSystemPrompt(sessionId, userId);
+        String replyText = assistant.reply(systemPrompt, recent, userContent);
+
+        ChatMessage botMsg = messages.save(ChatMessage.builder()
+                .session(s)
+                .userId(userId)
+                .role(ChatMessage.Role.ASSISTANT)
+                .content(replyText)
+                .build());
+
+        // 4) 세션 갱신 (updatedAt 갱신)
+        s.setUpdatedAt(Instant.now());
+        // sessions.save(s); // JPA 영속 상태면 생략 가능
+
+        return new MessageDto(
+                botMsg.getId(),
+                botMsg.getRole().name(),
+                botMsg.getContent(),
+                botMsg.getCreatedAt()
+        );
+    }
+
+    // -------------------- 내부 유틸 --------------------
+
+    private ChatSession ensureOwnership(Long userId, UUID sessionId) {
+        ChatSession s = sessions.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        if (!s.getUserId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+        return s;
+    }
+
+    /** 프로필 기반 시스템 프롬프트 생성 */
+    private String buildSystemPrompt(Long userId) {
+        Profile p = profiles.findById(userId).orElse(null);
+        String nick = (p != null && p.getNickname() != null) ? p.getNickname() : "사용자";
+        String tone = (p != null && p.getPreferredTone() != null) ? p.getPreferredTone().name() : "NEUTRAL";
+        String sens = (p != null && p.getContentSensitivity() != null) ? p.getContentSensitivity().name() : "MEDIUM";
+
+        return "당신은 공감적인 AI 상담사입니다.\n"
+                + "- 닉네임: " + nick + "\n"
+                + "- 톤: " + tone + "\n"
+                + "- 민감도: " + sens + "\n"
+                + "대화는 부드럽고 안전하게 이끌어 주세요.";
+    }
+
+    /** 세션의 최초 SYSTEM 메시지 내용을 읽어오거나, 없으면 새로 빌드 */
+    private String loadSystemPrompt(UUID sessionId, Long userId) {
+        var page = messages.findBySession_IdAndUserIdOrderByCreatedAtAsc(
+                sessionId, userId, PageRequest.of(0, 1)
+        );
+        return page.getContent().stream()
+                .filter(m -> m.getRole() == ChatMessage.Role.SYSTEM) // 엔티티 enum으로 비교
+                .map(ChatMessage::getContent)                        // 엔티티 getter
+                .findFirst()
+                .orElse(buildSystemPrompt(userId));
+    }
+}

--- a/src/main/java/com/example/hyu/service/checkin/CheckinService.java
+++ b/src/main/java/com/example/hyu/service/checkin/CheckinService.java
@@ -1,0 +1,13 @@
+package com.example.hyu.service.checkin;
+
+import com.example.hyu.dto.checkin.CheckinCreateResponse;
+import com.example.hyu.dto.checkin.CheckinStatsResponse;
+import com.example.hyu.dto.checkin.CheckinTodayResponse;
+
+import java.time.LocalDate;
+
+public interface CheckinService {
+    CheckinTodayResponse getToday(Long userId);
+    CheckinCreateResponse checkinToday(Long userId);
+    CheckinStatsResponse getStats(Long userId, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/example/hyu/service/checkin/CheckinServiceImpl.java
+++ b/src/main/java/com/example/hyu/service/checkin/CheckinServiceImpl.java
@@ -1,0 +1,86 @@
+package com.example.hyu.service.checkin;
+
+import com.example.hyu.dto.checkin.CheckinCreateResponse;
+import com.example.hyu.dto.checkin.CheckinStatsResponse;
+import com.example.hyu.dto.checkin.CheckinTodayResponse;
+import com.example.hyu.entity.Checkin;
+import com.example.hyu.repository.CheckinRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CheckinServiceImpl implements CheckinService {
+
+    private final CheckinRepository checkinRepo;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    private LocalDate today() { return LocalDate.now(ZONE); }
+    private Instant now() { return Instant.now(); }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CheckinTodayResponse getToday(Long userId) {
+        LocalDate today = today();
+        boolean checked = checkinRepo.existsByUserIdAndDate(userId, today);
+        int streak = computeStreak(userId, today);
+        boolean shouldPrompt = !checked; // 필요 시: 리마인더 정책 추가 가능
+        return new CheckinTodayResponse(checked, shouldPrompt, today, streak);
+    }
+
+    @Override
+    @Transactional
+    public CheckinCreateResponse checkinToday(Long userId) {
+        LocalDate today = today();
+        boolean exists = checkinRepo.existsByUserIdAndDate(userId, today);
+        if (!exists) {
+            checkinRepo.save(Checkin.builder()
+                    .userId(userId)
+                    .date(today)
+                    .createdAt(now())
+                    .build());
+        }
+        int streak = computeStreak(userId, today);
+        return new CheckinCreateResponse(!exists, today, streak);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CheckinStatsResponse getStats(Long userId, LocalDate from, LocalDate to) {
+        List<Checkin> list = checkinRepo.findAllByUserIdAndDateBetweenOrderByDateAsc(userId, from, to);
+
+        Map<LocalDate, Boolean> map = new LinkedHashMap<>();
+        LocalDate d = from;
+        while (!d.isAfter(to)) {
+            map.put(d, Boolean.FALSE);
+            d = d.plusDays(1);
+        }
+        for (Checkin c : list) {
+            map.put(c.getDate(), Boolean.TRUE);
+        }
+
+        int checkedDays = (int) map.values().stream().filter(Boolean::booleanValue).count();
+        int streak = computeStreak(userId, today());
+        return new CheckinStatsResponse(streak, map.size(), checkedDays, map);
+    }
+
+    /** 오늘을 끝점으로 뒤로 가며 연속 출석 계산 */
+    private int computeStreak(Long userId, LocalDate anchor) {
+        int s = 0;
+        LocalDate cur = anchor;
+        while (true) {
+            boolean exists = checkinRepo.existsByUserIdAndDate(userId, cur);
+            if (!exists) break;
+            s++;
+            cur = cur.minusDays(1);
+        }
+        return s;
+    }
+}

--- a/src/test/java/com/example/hyu/assistant/DummyAssistantClientTest.java
+++ b/src/test/java/com/example/hyu/assistant/DummyAssistantClientTest.java
@@ -1,0 +1,95 @@
+package com.example.hyu.assistant;
+
+/*
+ Testing library/framework: JUnit 5 (Jupiter) with standard Assertions.
+ Focus: Thorough unit tests for DummyAssistantClient.reply(...) covering happy paths, edge cases, and precedence rules.
+*/
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DummyAssistantClientTest {
+
+    private final DummyAssistantClient client = new DummyAssistantClient();
+
+    private static final String BLANK_PROMPT = "무슨 생각이 드셨는지 한두 문장으로 적어주실래요?";
+    private static final String GREETING_PROMPT = "안녕하세요\! 오늘 기분은 어떠세요? 편하게 말씀해 주세요.";
+    private static final String SHORT_PROMPT = "조금만 더 자세히 들려주실 수 있을까요? 어떤 상황이었는지도 함께 알려주세요.";
+    private static final String DEFAULT_PROMPT = "말해 주셔서 고마워요. 말씀하신 내용을 보니 꽤 신경 쓰이는 일이었겠어요. 그 상황에서 특히 힘들었던 점 한 가지를 꼽는다면 무엇일까요?";
+
+    private String call(String userMessage) {
+        // history and systemPrompt are ignored by DummyAssistantClient, use safe defaults
+        return client.reply("ignored-system-prompt", Collections.emptyList(), userMessage);
+    }
+
+    @Test
+    @DisplayName("Null or whitespace-only input -> request to write a couple of sentences")
+    void reply_whenNullOrBlank_returnsBlankPrompt() {
+        String[] inputs = new String[]{null, "", " ", "    ", "\n\t  "};
+        for (String in : inputs) {
+            assertEquals(BLANK_PROMPT, call(in), "Input should yield blank prompt: " + String.valueOf(in));
+        }
+    }
+
+    @Test
+    @DisplayName("Contains '안녕' anywhere -> greeting prompt (takes precedence over length check)")
+    void reply_whenContainsGreeting_returnsGreetingPrompt() {
+        String[] inputs = new String[]{
+                "안녕",
+                "안녕하세요",
+                "   안녕하세요   ",
+                "오늘도 친구에게 안녕이라고 인사했어요",
+                "안녕?" // short but greeting has precedence
+        };
+        for (String in : inputs) {
+            assertEquals(GREETING_PROMPT, call(in), "Greeting detection failed for: " + in);
+        }
+    }
+
+    @Test
+    @DisplayName("Short (< 8 chars) non-greeting -> ask for more details")
+    void reply_whenShortNonGreeting_returnsAskForDetails() {
+        String[] inputs = new String[]{
+                "힘들어", // length 3
+                "고민",   // length 2
+                "short",  // length 5
+                "1234567" // length 7
+        };
+        for (String in : inputs) {
+            assertEquals(SHORT_PROMPT, call(in), "Short input should request details: " + in);
+        }
+    }
+
+    @Test
+    @DisplayName("Exactly 8 chars (non-greeting) -> empathetic follow-up")
+    void reply_whenExactlyEightCharsNonGreeting_returnsDefault() {
+        assertEquals(DEFAULT_PROMPT, call("12345678"));
+        assertEquals(DEFAULT_PROMPT, call("abcdefgh"));
+    }
+
+    @Test
+    @DisplayName("Trimming is applied before rule checks")
+    void reply_appliesTrimBeforeRules() {
+        assertEquals(SHORT_PROMPT, call("   1234567   "));  // trimmed length 7 -> short
+        assertEquals(GREETING_PROMPT, call("   안녕   "));   // trimmed contains greeting
+        assertEquals(BLANK_PROMPT, call("   \t  \n  "));    // blank after trim
+    }
+
+    @Test
+    @DisplayName("Long non-greeting message -> empathetic follow-up")
+    void reply_whenLongNonGreeting_returnsDefault() {
+        String longMsg = "오늘 회사에서 일이 많아서 많이 지쳤어요. 그래도 내일은 더 나아졌으면 좋겠어요.";
+        assertEquals(DEFAULT_PROMPT, call(longMsg));
+    }
+
+    @Test
+    @DisplayName("Null history and systemPrompt are safely ignored")
+    void reply_whenNullHistoryAndSystemPrompt_stillWorks() {
+        String result = client.reply(null, null, "안녕하세요");
+        assertEquals(GREETING_PROMPT, result);
+    }
+}

--- a/src/test/java/com/example/hyu/controller/chat/ChatControllerTest.java
+++ b/src/test/java/com/example/hyu/controller/chat/ChatControllerTest.java
@@ -1,0 +1,264 @@
+package com.example.hyu.controller.chat;
+
+import com.example.hyu.dto.chat.CreateSessionResponse;
+import com.example.hyu.dto.chat.MessageDto;
+import com.example.hyu.dto.chat.SendMessageRequest;
+import com.example.hyu.dto.chat.SessionDto;
+import com.example.hyu.security.AuthPrincipal;
+import com.example.hyu.service.chat.ChatService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Testing stack: JUnit 5 (Jupiter), Spring Boot @WebMvcTest with MockMvc, Mockito via @MockBean,
+ * and spring-security-test for authentication mocking.
+ *
+ * Focus is on ChatController endpoints and especially parameters introduced/changed in the PR diff.
+ * We validate happy paths, pagination defaults/overrides, validation errors, and that AuthPrincipal's userId
+ * is propagated to ChatService methods.
+ */
+@WebMvcTest(ChatController.class)
+class ChatControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChatService chatService;
+
+    private static SecurityMockMvcRequestPostProcessors.RequestPostProcessor auth(AuthPrincipal principal, String... roles) {
+        // Wrap custom principal in a Spring Authentication for @AuthenticationPrincipal resolution.
+        TestingAuthenticationToken authentication =
+                new TestingAuthenticationToken(principal, null, roles.length == 0 ? new String[]{"ROLE_USER"} : roles);
+        authentication.setAuthenticated(true);
+        return SecurityMockMvcRequestPostProcessors.authentication(authentication);
+    }
+
+    private static AuthPrincipal principal(UUID userId) {
+        // Construct a minimal AuthPrincipal for tests. If AuthPrincipal has a different constructor,
+        // adapt here accordingly; tests rely only on getUserId().
+        return new AuthPrincipal(userId, "user@example.com", "User", List.of("ROLE_USER"));
+    }
+
+    @Nested
+    @DisplayName("POST /sessions - create session")
+    class CreateSession {
+
+        @Test
+        @DisplayName("should create a new session for the authenticated user and return response payload")
+        void createSession_ok() throws Exception {
+            UUID userId = UUID.randomUUID();
+            CreateSessionResponse stub = new CreateSessionResponse(UUID.randomUUID());
+            when(chatService.create(eq(userId))).thenReturn(stub);
+
+            mockMvc.perform(post("/sessions")
+                            .with(auth(principal(userId)))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.id", is(stub.id().toString())));
+
+            verify(chatService, times(1)).create(eq(userId));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /sessions - list sessions")
+    class ListSessions {
+
+        @Test
+        @DisplayName("should use default pagination (page=0,size=20) and return a page of sessions")
+        void list_defaultPaging() throws Exception {
+            UUID userId = UUID.randomUUID();
+            List<SessionDto> content = List.of(
+                    new SessionDto(UUID.randomUUID(), "Session A", Instant.now()),
+                    new SessionDto(UUID.randomUUID(), "Session B", Instant.now())
+            );
+            Page<SessionDto> page = new PageImpl<>(content, PageRequest.of(0, 20), 2);
+            when(chatService.list(eq(userId), eq(PageRequest.of(0, 20)))).thenReturn(page);
+
+            mockMvc.perform(get("/sessions")
+                            .with(auth(principal(userId)))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].id", is(content.get(0).id().toString())))
+                    .andExpect(jsonPath("$.content[0].title", is(content.get(0).title())))
+                    .andExpect(jsonPath("$.size", is(20)))
+                    .andExpect(jsonPath("$.number", is(0)))
+                    .andExpect(jsonPath("$.totalElements", is(2)));
+
+            verify(chatService).list(eq(userId), eq(PageRequest.of(0, 20)));
+        }
+
+        @Test
+        @DisplayName("should honor explicit page and size query params")
+        void list_customPaging() throws Exception {
+            UUID userId = UUID.randomUUID();
+            int pageNum = 3, size = 7;
+            List<SessionDto> content = List.of(new SessionDto(UUID.randomUUID(), "OnlyOne", Instant.now()));
+            Page<SessionDto> page = new PageImpl<>(content, PageRequest.of(pageNum, size), 15);
+            when(chatService.list(eq(userId), eq(PageRequest.of(pageNum, size)))).thenReturn(page);
+
+            mockMvc.perform(get("/sessions")
+                            .queryParam("page", String.valueOf(pageNum))
+                            .queryParam("size", String.valueOf(size))
+                            .with(auth(principal(userId)))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.number", is(pageNum)))
+                    .andExpect(jsonPath("$.size", is(size)));
+
+            verify(chatService).list(eq(userId), eq(PageRequest.of(pageNum, size)));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /sessions/{id}/messages - list messages")
+    class ListMessages {
+
+        @Test
+        @DisplayName("should return messages with default paging (page=0,size=50)")
+        void messages_defaultPaging() throws Exception {
+            UUID userId = UUID.randomUUID();
+            UUID sessionId = UUID.randomUUID();
+            List<MessageDto> messages = List.of(
+                    new MessageDto(UUID.randomUUID(), sessionId, "user", "Hello", Instant.now()),
+                    new MessageDto(UUID.randomUUID(), sessionId, "assistant", "Hi\!", Instant.now())
+            );
+            Page<MessageDto> page = new PageImpl<>(messages, PageRequest.of(0, 50), messages.size());
+            when(chatService.getMessages(eq(userId), eq(sessionId), eq(PageRequest.of(0, 50)))).thenReturn(page);
+
+            mockMvc.perform(get("/sessions/{id}/messages", sessionId)
+                            .with(auth(principal(userId)))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(2)))
+                    .andExpect(jsonPath("$.content[0].content", is("Hello")))
+                    .andExpect(jsonPath("$.size", is(50)))
+                    .andExpect(jsonPath("$.number", is(0)));
+
+            verify(chatService).getMessages(eq(userId), eq(sessionId), eq(PageRequest.of(0, 50)));
+        }
+
+        @Test
+        @DisplayName("should honor explicit page and size")
+        void messages_customPaging() throws Exception {
+            UUID userId = UUID.randomUUID();
+            UUID sessionId = UUID.randomUUID();
+            int pageNum = 2, size = 5;
+            List<MessageDto> messages = List.of(new MessageDto(UUID.randomUUID(), sessionId, "user", "Only", Instant.now()));
+            Page<MessageDto> page = new PageImpl<>(messages, PageRequest.of(pageNum, size), 11);
+            when(chatService.getMessages(eq(userId), eq(sessionId), eq(PageRequest.of(pageNum, size)))).thenReturn(page);
+
+            mockMvc.perform(get("/sessions/{id}/messages", sessionId)
+                            .queryParam("page", String.valueOf(pageNum))
+                            .queryParam("size", String.valueOf(size))
+                            .with(auth(principal(userId)))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.number", is(pageNum)))
+                    .andExpect(jsonPath("$.size", is(size)));
+
+            verify(chatService).getMessages(eq(userId), eq(sessionId), eq(PageRequest.of(pageNum, size)));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /sessions/{id}/messages - send message")
+    class SendMessage {
+
+        @Test
+        @DisplayName("should send message and return created message dto")
+        void send_ok() throws Exception {
+            UUID userId = UUID.randomUUID();
+            UUID sessionId = UUID.randomUUID();
+            String content = "How are you?";
+            MessageDto returned = new MessageDto(UUID.randomUUID(), sessionId, "user", content, Instant.now());
+            when(chatService.send(eq(userId), eq(sessionId), eq(content))).thenReturn(returned);
+
+            String body = "{\"content\":\"" + content + "\"}";
+
+            mockMvc.perform(post("/sessions/{id}/messages", sessionId)
+                            .with(auth(principal(userId)))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body.getBytes(StandardCharsets.UTF_8))
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.sessionId", is(sessionId.toString())))
+                    .andExpect(jsonPath("$.content", is(content)));
+
+            verify(chatService).send(eq(userId), eq(sessionId), eq(content));
+        }
+
+        @Test
+        @DisplayName("should return 400 Bad Request when content is blank (validation failure)")
+        void send_validationError_blank() throws Exception {
+            UUID userId = UUID.randomUUID();
+            UUID sessionId = UUID.randomUUID();
+
+            // Assuming @Valid enforces non-blank content on SendMessageRequest.content().
+            String body = "{\"content\":\"   \"}";
+
+            mockMvc.perform(post("/sessions/{id}/messages", sessionId)
+                            .with(auth(principal(userId)))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+
+            verify(chatService, never()).send(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("should propagate exact userId and message content to ChatService")
+        void send_verifiesArguments() throws Exception {
+            UUID userId = UUID.randomUUID();
+            UUID sessionId = UUID.randomUUID();
+            String content = "Ping";
+            MessageDto returned = new MessageDto(UUID.randomUUID(), sessionId, "user", content, Instant.now());
+            when(chatService.send(any(UUID.class), any(UUID.class), any(String.class))).thenReturn(returned);
+
+            mockMvc.perform(post("/sessions/{id}/messages", sessionId)
+                            .with(auth(principal(userId)))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\":\"" + content + "\"}"))
+                    .andExpect(status().isOk());
+
+            ArgumentCaptor<UUID> userCaptor = ArgumentCaptor.forClass(UUID.class);
+            ArgumentCaptor<UUID> sessionCaptor = ArgumentCaptor.forClass(UUID.class);
+            ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+            verify(chatService).send(userCaptor.capture(), sessionCaptor.capture(), contentCaptor.capture());
+
+            assert userCaptor.getValue().equals(userId) : "Expected userId to be propagated from AuthPrincipal";
+            assert sessionCaptor.getValue().equals(sessionId) : "Expected path variable session id to be propagated";
+            assert contentCaptor.getValue().equals(content) : "Expected request content to be propagated";
+        }
+    }
+}

--- a/src/test/java/com/example/hyu/notification/LoggingNotificationSenderTest.java
+++ b/src/test/java/com/example/hyu/notification/LoggingNotificationSenderTest.java
@@ -1,0 +1,92 @@
+package com.example.hyu.notification;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoggingNotificationSenderTest {
+
+    private LoggingNotificationSender sender;
+    private Logger underlyingLogger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        sender = new LoggingNotificationSender();
+        underlyingLogger = (Logger) LoggerFactory.getLogger(LoggingNotificationSender.class);
+        // Ensure INFO is enabled
+        underlyingLogger.setLevel(Level.INFO);
+
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        underlyingLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (underlyingLogger \!= null && listAppender \!= null) {
+            underlyingLogger.detachAppender(listAppender);
+            listAppender.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("sendInApp logs formatted INFO message for typical inputs")
+    void sendInApp_logsInfo_withExpectedFormat() {
+        Long userId = 42L;
+        String title = "Welcome";
+        String body = "Hello there";
+
+        sender.sendInApp(userId, title, body);
+
+        List<ILoggingEvent> events = listAppender.list;
+        assertEquals(1, events.size(), "Exactly one log event should be emitted");
+        ILoggingEvent e = events.get(0);
+        assertEquals(Level.INFO, e.getLevel(), "Log level should be INFO");
+        assertEquals(LoggingNotificationSender.class.getName(), e.getLoggerName(), "Logger name should match class");
+        assertEquals("[IN-APP] userId=42 | Welcome - Hello there", e.getFormattedMessage(), "Message format should match");
+    }
+
+    @Test
+    @DisplayName("sendInApp tolerates nulls and logs 'null' placeholders")
+    void sendInApp_handlesNulls() {
+        sender.sendInApp(null, null, "Body");
+
+        List<ILoggingEvent> events = listAppender.list;
+        assertEquals(1, events.size(), "One log event expected");
+        ILoggingEvent e = events.get(0);
+        assertEquals(Level.INFO, e.getLevel(), "Should still log at INFO");
+        assertEquals("[IN-APP] userId=null | null - Body", e.getFormattedMessage(), "Nulls should be rendered as 'null'");
+    }
+
+    @Test
+    @DisplayName("sendInApp logs long strings without truncation")
+    void sendInApp_logsLongStrings() {
+        Long userId = 7L;
+        String title = "T".repeat(2000);
+        String body = "B".repeat(3000);
+
+        sender.sendInApp(userId, title, body);
+
+        List<ILoggingEvent> events = listAppender.list;
+        assertEquals(1, events.size(), "One log event expected");
+        ILoggingEvent e = events.get(0);
+        String msg = e.getFormattedMessage();
+
+        assertTrue(msg.startsWith("[IN-APP] userId=7 | "), "Prefix should match");
+        assertTrue(msg.contains(" - "), "Separator should be present");
+        assertTrue(msg.contains(title), "Title should be fully present");
+        assertTrue(msg.endsWith(body), "Body should be fully present at the end");
+        assertEquals(Level.INFO, e.getLevel(), "Level should be INFO");
+    }
+}

--- a/src/test/java/com/example/hyu/scheduler/WeeklySummarySchedulerTest.java
+++ b/src/test/java/com/example/hyu/scheduler/WeeklySummarySchedulerTest.java
@@ -1,0 +1,230 @@
+package com.example.hyu.scheduler;
+
+import com.example.hyu.entity.Profile;
+import com.example.hyu.entity.WeeklySummary;
+import com.example.hyu.notification.NotificationSender;
+import com.example.hyu.repository.CheckinRepository;
+import com.example.hyu.repository.ProfileRepository;
+import com.example.hyu.repository.WeeklySummaryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Note: Tests use JUnit 5 (Jupiter) and Mockito, consistent with common Spring Boot testing setups.
+ * Plain unit tests (no Spring context). External dependencies are mocked.
+ */
+@ExtendWith(MockitoExtension.class)
+class WeeklySummarySchedulerTest {
+
+    private ProfileRepository profileRepo;
+    private CheckinRepository checkinRepo;
+    private WeeklySummaryRepository weeklyRepo;
+    private NotificationSender notifier;
+
+    private WeeklySummaryScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        profileRepo = mock(ProfileRepository.class);
+        checkinRepo = mock(CheckinRepository.class);
+        weeklyRepo = mock(WeeklySummaryRepository.class);
+        notifier = mock(NotificationSender.class);
+
+        scheduler = new WeeklySummaryScheduler(profileRepo, checkinRepo, weeklyRepo, notifier);
+    }
+
+    private static LocalDate todayKST() {
+        return LocalDate.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    private static LocalDate expectedWeekStart(LocalDate today) {
+        return today.minusWeeks(1).with(DayOfWeek.MONDAY);
+    }
+
+    private static LocalDate expectedWeekEnd(LocalDate weekStart) {
+        return weekStart.plusDays(6);
+    }
+
+    @Test
+    @DisplayName("run: sends weekly summary for opted-in profile when not already sent and persists summary")
+    void run_sendsSummaryForOptedInProfile_whenNotAlreadySent() {
+        LocalDate today = todayKST();
+        LocalDate weekStart = expectedWeekStart(today);
+        LocalDate weekEnd = expectedWeekEnd(weekStart);
+
+        Profile p1 = mock(Profile.class);
+        when(p1.isWeeklySummary()).thenReturn(true);
+        when(p1.getUserId()).thenReturn(1L);
+
+        when(profileRepo.findAll()).thenReturn(List.of(p1));
+        when(weeklyRepo.existsByUserIdAndWeekStart(1L, weekStart)).thenReturn(false);
+
+        @SuppressWarnings({"rawtypes","unchecked"})
+        List fiveCheckins = Arrays.asList(new Object[5]); // size = 5 is all we need
+        when(checkinRepo.findAllByUserIdAndDateBetweenOrderByDateAsc(1L, weekStart, weekEnd))
+                .thenReturn((List) fiveCheckins);
+
+        // Allow save to succeed
+        when(weeklyRepo.save(any(WeeklySummary.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        String expectedContent = String.format("지난주 출석: %d/7일. 계속 화이팅이에요\! (%s ~ %s)", 5, weekStart, weekEnd);
+
+        scheduler.run();
+
+        verify(weeklyRepo).existsByUserIdAndWeekStart(1L, weekStart);
+        verify(checkinRepo).findAllByUserIdAndDateBetweenOrderByDateAsc(1L, weekStart, weekEnd);
+        verify(weeklyRepo).save(any(WeeklySummary.class));
+        verify(notifier).sendInApp(1L, "주간 요약", expectedContent);
+
+        verifyNoMoreInteractions(notifier);
+    }
+
+    @Test
+    @DisplayName("run: skips processing when a weekly summary already exists for the user")
+    void run_skipsWhenAlreadySent() {
+        LocalDate today = todayKST();
+        LocalDate weekStart = expectedWeekStart(today);
+
+        Profile p1 = mock(Profile.class);
+        when(p1.isWeeklySummary()).thenReturn(true);
+        when(p1.getUserId()).thenReturn(1L);
+
+        when(profileRepo.findAll()).thenReturn(List.of(p1));
+        when(weeklyRepo.existsByUserIdAndWeekStart(1L, weekStart)).thenReturn(true);
+
+        scheduler.run();
+
+        verify(weeklyRepo).existsByUserIdAndWeekStart(1L, weekStart);
+        verify(checkinRepo, never()).findAllByUserIdAndDateBetweenOrderByDateAsc(anyLong(), any(), any());
+        verify(weeklyRepo, never()).save(any());
+        verify(notifier, never()).sendInApp(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("run: continues processing other users when one user's processing throws an exception")
+    void run_continuesOnExceptionAndProcessesNextUser() {
+        LocalDate today = todayKST();
+        LocalDate weekStart = expectedWeekStart(today);
+        LocalDate weekEnd = expectedWeekEnd(weekStart);
+
+        Profile p1 = mock(Profile.class);
+        when(p1.isWeeklySummary()).thenReturn(true);
+        when(p1.getUserId()).thenReturn(1L);
+
+        Profile p2 = mock(Profile.class);
+        when(p2.isWeeklySummary()).thenReturn(true);
+        when(p2.getUserId()).thenReturn(2L);
+
+        when(profileRepo.findAll()).thenReturn(List.of(p1, p2));
+
+        when(weeklyRepo.existsByUserIdAndWeekStart(1L, weekStart)).thenReturn(false);
+        when(weeklyRepo.existsByUserIdAndWeekStart(2L, weekStart)).thenReturn(false);
+
+        @SuppressWarnings({"rawtypes","unchecked"})
+        List threeCheckins = Arrays.asList(new Object[3]);
+        @SuppressWarnings({"rawtypes","unchecked"})
+        List sevenCheckins = Arrays.asList(new Object[7]);
+
+        when(checkinRepo.findAllByUserIdAndDateBetweenOrderByDateAsc(1L, weekStart, weekEnd))
+                .thenReturn((List) threeCheckins);
+        when(checkinRepo.findAllByUserIdAndDateBetweenOrderByDateAsc(2L, weekStart, weekEnd))
+                .thenReturn((List) sevenCheckins);
+
+        // First save throws, second save succeeds
+        when(weeklyRepo.save(any(WeeklySummary.class))).thenAnswer(new Answer<WeeklySummary>() {
+            int count = 0;
+            @Override public WeeklySummary answer(InvocationOnMock invocation) {
+                count++;
+                if (count == 1) {
+                    throw new RuntimeException("fail first user");
+                }
+                return invocation.getArgument(0);
+            }
+        });
+
+        String expectedContentP2 = String.format("지난주 출석: %d/7일. 계속 화이팅이에요\! (%s ~ %s)", 7, weekStart, weekEnd);
+
+        scheduler.run();
+
+        // First user failed before notification
+        verify(notifier, never()).sendInApp(eq(1L), anyString(), anyString());
+        // Second user processed successfully
+        verify(notifier).sendInApp(2L, "주간 요약", expectedContentP2);
+    }
+
+    @Test
+    @DisplayName("run: filters out profiles with weekly summary disabled")
+    void run_filtersOutProfilesWithWeeklySummaryDisabled() {
+        LocalDate today = todayKST();
+        LocalDate weekStart = expectedWeekStart(today);
+        LocalDate weekEnd = expectedWeekEnd(weekStart);
+
+        Profile p1 = mock(Profile.class);
+        when(p1.isWeeklySummary()).thenReturn(true);
+        when(p1.getUserId()).thenReturn(1L);
+
+        Profile p2 = mock(Profile.class);
+        when(p2.isWeeklySummary()).thenReturn(false);
+        when(p2.getUserId()).thenReturn(2L);
+
+        when(profileRepo.findAll()).thenReturn(List.of(p1, p2));
+        when(weeklyRepo.existsByUserIdAndWeekStart(1L, weekStart)).thenReturn(false);
+
+        @SuppressWarnings({"rawtypes","unchecked"})
+        List fiveCheckins = Arrays.asList(new Object[5]);
+        when(checkinRepo.findAllByUserIdAndDateBetweenOrderByDateAsc(1L, weekStart, weekEnd))
+                .thenReturn((List) fiveCheckins);
+
+        when(weeklyRepo.save(any(WeeklySummary.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        scheduler.run();
+
+        verify(weeklyRepo).existsByUserIdAndWeekStart(1L, weekStart);
+        verify(weeklyRepo, never()).existsByUserIdAndWeekStart(eq(2L), any());
+        verify(notifier).sendInApp(eq(1L), eq("주간 요약"), anyString());
+        verify(notifier, never()).sendInApp(eq(2L), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("run: builds content correctly when there are zero check-ins")
+    void run_buildsContentWithZeroCheckedDays() {
+        LocalDate today = todayKST();
+        LocalDate weekStart = expectedWeekStart(today);
+        LocalDate weekEnd = expectedWeekEnd(weekStart);
+
+        Profile p1 = mock(Profile.class);
+        when(p1.isWeeklySummary()).thenReturn(true);
+        when(p1.getUserId()).thenReturn(1L);
+
+        when(profileRepo.findAll()).thenReturn(List.of(p1));
+        when(weeklyRepo.existsByUserIdAndWeekStart(1L, weekStart)).thenReturn(false);
+
+        @SuppressWarnings({"rawtypes","unchecked"})
+        List empty = Collections.emptyList();
+        when(checkinRepo.findAllByUserIdAndDateBetweenOrderByDateAsc(1L, weekStart, weekEnd))
+                .thenReturn((List) empty);
+
+        when(weeklyRepo.save(any(WeeklySummary.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        scheduler.run();
+
+        String expectedContent = String.format("지난주 출석: %d/7일. 계속 화이팅이에요\! (%s ~ %s)", 0, weekStart, weekEnd);
+        verify(notifier).sendInApp(1L, "주간 요약", expectedContent);
+    }
+}

--- a/src/test/java/com/example/hyu/service/chat/ChatServiceImplTest.java
+++ b/src/test/java/com/example/hyu/service/chat/ChatServiceImplTest.java
@@ -1,0 +1,367 @@
+/*
+ Testing library/framework note:
+ - Using JUnit 5 (org.junit.jupiter.api) with Mockito (org.mockito.junit.jupiter.MockitoExtension).
+ - Assertions: primarily JUnit's Assertions, consistent with most existing tests.
+ - Plain unit tests (no Spring context). External dependencies are mocked.
+*/
+package com.example.hyu.service.chat;
+
+import com.example.hyu.assistant.AssistantClient;
+import com.example.hyu.dto.chat.CreateSessionResponse;
+import com.example.hyu.dto.chat.MessageDto;
+import com.example.hyu.dto.chat.SessionDto;
+import com.example.hyu.entity.ChatMessage;
+import com.example.hyu.entity.ChatSession;
+import com.example.hyu.entity.Profile;
+import com.example.hyu.repository.ProfileRepository;
+import com.example.hyu.repository.chat.ChatMessageRepository;
+import com.example.hyu.repository.chat.ChatSessionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceImplTest {
+
+    @Mock ChatSessionRepository sessions;
+    @Mock ChatMessageRepository messages;
+    @Mock AssistantClient assistant;
+    @Mock ProfileRepository profiles;
+
+    @InjectMocks ChatServiceImpl service;
+
+    private final Long userId = 101L;
+    private final UUID sessionId = UUID.randomUUID();
+
+    @BeforeEach
+    void init() {
+        // @InjectMocks wires fields
+    }
+
+    private ChatSession newSession(Long uid) {
+        ChatSession s = ChatSession.builder()
+                .userId(uid)
+                .status(ChatSession.Status.OPEN)
+                .build();
+        s.setUpdatedAt(Instant.now());
+        return s;
+    }
+
+    private ChatMessage msg(Long id, ChatMessage.Role role, String content, Instant createdAt) {
+        ChatMessage m = ChatMessage.builder()
+                .role(role)
+                .content(content)
+                .build();
+        try {
+            java.lang.reflect.Field fId = ChatMessage.class.getDeclaredField("id");
+            fId.setAccessible(true);
+            fId.set(m, id);
+        } catch (Exception ignored) {}
+        try {
+            java.lang.reflect.Field fTs = ChatMessage.class.getDeclaredField("createdAt");
+            fTs.setAccessible(true);
+            fTs.set(m, createdAt);
+        } catch (Exception ignored) {}
+        return m;
+    }
+
+    @Nested
+    @DisplayName("create(userId)")
+    class CreateTests {
+        @Test
+        @DisplayName("creates session and saves initial SYSTEM message with default prompt when profile missing")
+        void create_savesSystemMessage_withDefaultNickname() {
+            when(profiles.findById(userId)).thenReturn(Optional.empty());
+
+            ArgumentCaptor<ChatSession> sessionCap = ArgumentCaptor.forClass(ChatSession.class);
+            doAnswer(inv -> inv.getArgument(0)).when(sessions).save(sessionCap.capture());
+
+            ArgumentCaptor<ChatMessage> msgCap = ArgumentCaptor.forClass(ChatMessage.class);
+            doAnswer(inv -> inv.getArgument(0)).when(messages).save(msgCap.capture());
+
+            CreateSessionResponse res = service.create(userId);
+            assertNotNull(res);
+            verify(sessions, times(1)).save(any(ChatSession.class));
+            ChatSession saved = sessionCap.getValue();
+            assertEquals(userId, saved.getUserId());
+            assertEquals(ChatSession.Status.OPEN, saved.getStatus());
+
+            verify(messages, times(1)).save(any(ChatMessage.class));
+            ChatMessage sys = msgCap.getValue();
+            assertEquals(ChatMessage.Role.SYSTEM, sys.getRole());
+            assertNotNull(sys.getContent());
+            assertTrue(sys.getContent().contains("- 닉네임: 사용자"));
+            assertTrue(sys.getContent().contains("- 톤: NEUTRAL"));
+            assertTrue(sys.getContent().contains("- 민감도: MEDIUM"));
+        }
+
+        @Test
+        @DisplayName("includes profile nickname when available; tone/sensitivity default if null")
+        void create_usesProfileNickname_whenAvailable() {
+            Profile p = mock(Profile.class);
+            when(p.getNickname()).thenReturn("Alex");
+            when(p.getPreferredTone()).thenReturn(null);
+            when(p.getContentSensitivity()).thenReturn(null);
+            when(profiles.findById(userId)).thenReturn(Optional.of(p));
+
+            ArgumentCaptor<ChatMessage> msgCap = ArgumentCaptor.forClass(ChatMessage.class);
+            when(messages.save(msgCap.capture())).thenAnswer(inv -> inv.getArgument(0));
+            when(sessions.save(any(ChatSession.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            service.create(userId);
+
+            ChatMessage sys = msgCap.getValue();
+            String prompt = sys.getContent();
+            assertTrue(prompt.contains("- 닉네임: Alex"));
+            assertTrue(prompt.contains("- 톤: NEUTRAL"));
+            assertTrue(prompt.contains("- 민감도: MEDIUM"));
+        }
+
+        @Test
+        @DisplayName("returns non-null session id when repository assigns UUID")
+        void create_returnsResponseIdNotNull_whenRepoAssignsId() {
+            when(profiles.findById(userId)).thenReturn(Optional.empty());
+            when(messages.save(any(ChatMessage.class))).thenAnswer(inv -> inv.getArgument(0));
+            doAnswer(inv -> {
+                ChatSession s = inv.getArgument(0);
+                try {
+                    java.lang.reflect.Field f = ChatSession.class.getDeclaredField("id");
+                    f.setAccessible(true);
+                    f.set(s, java.util.UUID.randomUUID());
+                } catch (Exception ignored) {}
+                return s;
+            }).when(sessions).save(any(ChatSession.class));
+
+            CreateSessionResponse res = service.create(userId);
+            assertNotNull(res);
+            assertNotNull(res.id());
+        }
+    }
+
+    @Nested
+    @DisplayName("list(userId, pageable)")
+    class ListTests {
+        @Test
+        @DisplayName("returns mapped session DTOs ordered by updatedAt desc")
+        void list_mapsSessions() {
+            ChatSession s1 = newSession(userId);
+            ChatSession s2 = newSession(userId);
+            s1.setUpdatedAt(Instant.now().minusSeconds(10));
+            s2.setUpdatedAt(Instant.now());
+
+            Page<ChatSession> page = new PageImpl<>(List.of(s2, s1), PageRequest.of(0, 10), 2);
+            when(sessions.findByUserIdOrderByUpdatedAtDesc(eq(userId), any(Pageable.class)))
+                    .thenReturn(page);
+
+            Page<SessionDto> result = service.list(userId, PageRequest.of(0, 10));
+            assertEquals(2, result.getTotalElements());
+            List<SessionDto> content = result.getContent();
+            assertEquals("OPEN", content.get(0).status());
+            assertTrue(content.get(0).updatedAt().isAfter(content.get(1).updatedAt()));
+        }
+
+        @Test
+        @DisplayName("returns empty page when none exist")
+        void list_empty() {
+            when(sessions.findByUserIdOrderByUpdatedAtDesc(eq(userId), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+            Page<SessionDto> result = service.list(userId, PageRequest.of(0, 10));
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("getMessages(userId, sessionId, pageable)")
+    class GetMessagesTests {
+        @Test
+        @DisplayName("throws 404 when session not found")
+        void getMessages_sessionMissing_404() {
+            when(sessions.findById(sessionId)).thenReturn(Optional.empty());
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> service.getMessages(userId, sessionId, PageRequest.of(0, 20)));
+            assertEquals(404, ex.getStatusCode().value());
+        }
+
+        @Test
+        @DisplayName("throws 404 when session belongs to a different user")
+        void getMessages_userMismatch_404() {
+            ChatSession other = newSession(999L);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(other));
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> service.getMessages(userId, sessionId, PageRequest.of(0, 20)));
+            assertEquals(404, ex.getStatusCode().value());
+        }
+
+        @Test
+        @DisplayName("returns mapped MessageDto page on success")
+        void getMessages_success() {
+            ChatSession s = newSession(userId);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(s));
+
+            ChatMessage m1 = msg(1L, ChatMessage.Role.USER, "hi", Instant.now().minusSeconds(5));
+            ChatMessage m2 = msg(2L, ChatMessage.Role.ASSISTANT, "hello", Instant.now());
+            Page<ChatMessage> page = new PageImpl<>(List.of(m1, m2), PageRequest.of(0, 20), 2);
+            when(messages.findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class)))
+                    .thenReturn(page);
+
+            Page<MessageDto> result = service.getMessages(userId, sessionId, PageRequest.of(0, 20));
+            assertEquals(2, result.getTotalElements());
+            assertEquals("USER", result.getContent().get(0).role());
+            assertEquals("ASSISTANT", result.getContent().get(1).role());
+            assertEquals("hello", result.getContent().get(1).content());
+        }
+
+        @Test
+        @DisplayName("returns empty page when no messages")
+        void getMessages_empty() {
+            ChatSession s = newSession(userId);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(s));
+            when(messages.findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
+            Page<MessageDto> result = service.getMessages(userId, sessionId, PageRequest.of(0, 20));
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("send(userId, sessionId, userContent)")
+    class SendTests {
+        @Test
+        @DisplayName("persists user message, calls assistant with existing system prompt, saves bot reply, updates session timestamp, and preserves call order")
+        void send_happyPath_withExistingSystemPrompt() {
+            ChatSession s = newSession(userId);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(s));
+
+            Page<ChatMessage> recent = new PageImpl<>(List.of(
+                    msg(10L, ChatMessage.Role.USER, "earlier", Instant.now().minusSeconds(60))
+            ));
+            Page<ChatMessage> sysPage = new PageImpl<>(List.of(
+                    msg(11L, ChatMessage.Role.SYSTEM, "SYS_PROMPT", Instant.now().minusSeconds(120))
+            ));
+
+            when(messages.findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class)))
+                    .thenAnswer(inv -> {
+                        Pageable p = inv.getArgument(2);
+                        return p.getPageSize() == 50 ? recent : sysPage;
+                    });
+
+            when(messages.save(any(ChatMessage.class))).thenAnswer(inv -> {
+                ChatMessage m = inv.getArgument(0);
+                try {
+                    java.lang.reflect.Field f = ChatMessage.class.getDeclaredField("createdAt");
+                    f.setAccessible(true);
+                    if (f.get(m) == null) f.set(m, Instant.now());
+                } catch (Exception ignored) {}
+                return m;
+            });
+
+            when(assistant.reply(eq("SYS_PROMPT"), anyList(), eq("hello there"))).thenReturn("BOT_REPLY");
+
+            MessageDto dto = service.send(userId, sessionId, "hello there");
+            assertNotNull(dto);
+            assertEquals("ASSISTANT", dto.role());
+            assertEquals("BOT_REPLY", dto.content());
+            assertNotNull(dto.createdAt());
+            assertNotNull(s.getUpdatedAt());
+
+            // Verify order: save(USER) -> find(recent) -> find(sys) -> assistant.reply -> save(ASSISTANT)
+            InOrder inOrder = inOrder(messages, assistant);
+            inOrder.verify(messages).save(argThat(m -> m.getRole() == ChatMessage.Role.USER));
+            inOrder.verify(messages, times(1)).findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class));
+            inOrder.verify(messages, times(1)).findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class));
+            inOrder.verify(assistant).reply(eq("SYS_PROMPT"), anyList(), eq("hello there"));
+            inOrder.verify(messages).save(argThat(m -> m.getRole() == ChatMessage.Role.ASSISTANT));
+        }
+
+        @Test
+        @DisplayName("uses PageRequest sizes 50 (history) and 1 (system prompt)")
+        void send_usesExpectedPageSizes() {
+            ChatSession s = newSession(userId);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(s));
+
+            when(messages.findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of()));
+
+            when(messages.save(any(ChatMessage.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(assistant.reply(anyString(), anyList(), anyString())).thenReturn("ok");
+
+            service.send(userId, sessionId, "hi");
+
+            ArgumentCaptor<Pageable> cap = ArgumentCaptor.forClass(Pageable.class);
+            verify(messages, times(2)).findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), cap.capture());
+            List<Integer> sizes = cap.getAllValues().stream().map(Pageable::getPageSize).sorted().toList();
+            assertEquals(List.of(1, 50), sizes);
+        }
+
+        @Test
+        @DisplayName("builds system prompt from profile when no SYSTEM message present")
+        void send_buildsSystemPrompt_whenNoSystemMessage() {
+            ChatSession s = newSession(userId);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(s));
+
+            Page<ChatMessage> recent = new PageImpl<>(Collections.emptyList());
+            Page<ChatMessage> emptySys = new PageImpl<>(Collections.emptyList());
+
+            when(messages.findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class)))
+                    .thenAnswer(inv -> {
+                        Pageable p = inv.getArgument(2);
+                        return p.getPageSize() == 50 ? recent : emptySys;
+                    });
+
+            when(messages.save(any(ChatMessage.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            when(profiles.findById(userId)).thenReturn(Optional.empty());
+
+            ArgumentCaptor<String> systemPromptCap = ArgumentCaptor.forClass(String.class);
+            when(assistant.reply(systemPromptCap.capture(), anyList(), eq("hey"))).thenReturn("ok");
+
+            service.send(userId, sessionId, "hey");
+
+            String prompt = systemPromptCap.getValue();
+            assertNotNull(prompt);
+            assertTrue(prompt.contains("- 닉네임: 사용자"));
+            assertTrue(prompt.contains("대화는 부드럽고 안전하게 이끌어 주세요."));
+        }
+
+        @Test
+        @DisplayName("returns empty assistant content as-is")
+        void send_emptyAssistantReply_returnsEmptyContent() {
+            ChatSession s = newSession(userId);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(s));
+
+            when(messages.findBySession_IdAndUserIdOrderByCreatedAtAsc(eq(sessionId), eq(userId), any(Pageable.class)))
+                    .thenReturn(new PageImpl<>(List.of()), new PageImpl<>(List.of())); // history, system
+            when(messages.save(any(ChatMessage.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(assistant.reply(anyString(), anyList(), eq("ping"))).thenReturn("");
+
+            MessageDto dto = service.send(userId, sessionId, "ping");
+            assertNotNull(dto);
+            assertEquals("ASSISTANT", dto.role());
+            assertEquals("", dto.content());
+        }
+
+        @Test
+        @DisplayName("throws 404 when sending to a session owned by a different user")
+        void send_userMismatch_404() {
+            ChatSession other = newSession(999L);
+            when(sessions.findById(sessionId)).thenReturn(Optional.of(other));
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> service.send(userId, sessionId, "msg"));
+            assertEquals(404, ex.getStatusCode().value());
+        }
+    }
+}

--- a/src/test/java/com/example/hyu/service/checkin/CheckinServiceImplTest.java
+++ b/src/test/java/com/example/hyu/service/checkin/CheckinServiceImplTest.java
@@ -1,0 +1,218 @@
+/*
+  Testing library/framework note:
+  - This test class is written for JUnit 5 (Jupiter) with Mockito (MockitoExtension).
+  - It uses AssertJ assertions if available; otherwise falls back to JUnit assertions.
+*/
+package com.example.hyu.service.checkin;
+
+import com.example.hyu.dto.checkin.CheckinCreateResponse;
+import com.example.hyu.dto.checkin.CheckinStatsResponse;
+import com.example.hyu.dto.checkin.CheckinTodayResponse;
+import com.example.hyu.entity.Checkin;
+import com.example.hyu.repository.CheckinRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for CheckinServiceImpl focusing on the diffed logic.
+ * We mock CheckinRepository and control date-dependent behavior by computing today's date
+ * according to the implementation's ZoneId (Asia/Seoul).
+ */
+@ExtendWith(MockitoExtension.class)
+class CheckinServiceImplTest {
+
+    @Mock
+    private CheckinRepository checkinRepository;
+
+    private CheckinServiceImpl service;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    private long userId;
+
+    @BeforeEach
+    void setUp() {
+        service = new CheckinServiceImpl(checkinRepository);
+        userId = 42L;
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(ZONE);
+    }
+
+    @Nested
+    @DisplayName("getToday")
+    class GetToday {
+
+        @Test
+        @DisplayName("returns checked=false, shouldPrompt=true, streak=0 when user has not checked in today and no prior streak")
+        void notCheckedToday_noStreak() {
+            LocalDate t = today();
+            when(checkinRepository.existsByUserIdAndDate(userId, t)).thenReturn(false);
+            // computeStreak will query today first => false -> streak=0
+            CheckinTodayResponse res = service.getToday(userId);
+
+            // Prefer AssertJ if present; also include JUnit assertions for compatibility
+            assertNotNull(res);
+            assertThat(res.date()).isEqualTo(t);
+            assertThat(res.checked()).isFalse();
+            assertThat(res.shouldPrompt()).isTrue();
+            assertThat(res.streak()).isZero();
+
+            verify(checkinRepository, times(1)).existsByUserIdAndDate(userId, t);
+        }
+
+        @Test
+        @DisplayName("returns checked=true, shouldPrompt=false, streak counts consecutive past days including today")
+        void checkedToday_withStreak() {
+            LocalDate t = today();
+            // Streak of 3 days: today, t-1, t-2 true; then t-3 false
+            when(checkinRepository.existsByUserIdAndDate(userId, t)).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, t.minusDays(1))).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, t.minusDays(2))).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, t.minusDays(3))).thenReturn(false);
+
+            CheckinTodayResponse res = service.getToday(userId);
+
+            assertThat(res.checked()).isTrue();
+            assertThat(res.shouldPrompt()).isFalse();
+            assertThat(res.date()).isEqualTo(t);
+            assertThat(res.streak()).isEqualTo(3);
+
+            // Verify minimal essential interactions
+            verify(checkinRepository, times(1)).existsByUserIdAndDate(userId, t);
+            verify(checkinRepository, times(1)).existsByUserIdAndDate(userId, t.minusDays(1));
+            verify(checkinRepository, times(1)).existsByUserIdAndDate(userId, t.minusDays(2));
+            verify(checkinRepository, times(1)).existsByUserIdAndDate(userId, t.minusDays(3));
+        }
+    }
+
+    @Nested
+    @DisplayName("checkinToday")
+    class CheckinToday {
+
+        @Test
+        @DisplayName("creates a checkin when none exists for today; returns created=true and updated streak")
+        void createsWhenMissing() {
+            LocalDate t = today();
+
+            when(checkinRepository.existsByUserIdAndDate(userId, t)).thenReturn(false);
+            // Streak after saving should be computed as 1 (today only), so stub exists for today as true
+            when(checkinRepository.existsByUserIdAndDate(userId, t)).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, t.minusDays(1))).thenReturn(false);
+
+            ArgumentCaptor<Checkin> captor = ArgumentCaptor.forClass(Checkin.class);
+            // save returns the same entity (common Mockito default), no need to stub return explicitly
+
+            CheckinCreateResponse res = service.checkinToday(userId);
+
+            assertThat(res).isNotNull();
+            assertThat(res.created()).isTrue();
+            assertThat(res.date()).isEqualTo(t);
+            assertThat(res.streak()).isEqualTo(1);
+
+            verify(checkinRepository).save(captor.capture());
+            Checkin saved = captor.getValue();
+            assertThat(saved.getUserId()).isEqualTo(userId);
+            assertThat(saved.getDate()).isEqualTo(t);
+            assertThat(saved.getCreatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("does not create duplicate when already checked in; returns created=false and current streak")
+        void noDuplicateWhenExists() {
+            LocalDate t = today();
+
+            when(checkinRepository.existsByUserIdAndDate(userId, t)).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, t.minusDays(1))).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, t.minusDays(2))).thenReturn(false);
+
+            CheckinCreateResponse res = service.checkinToday(userId);
+
+            assertThat(res.created()).isFalse();
+            assertThat(res.date()).isEqualTo(t);
+            assertThat(res.streak()).isEqualTo(2);
+
+            verify(checkinRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("getStats")
+    class GetStats {
+
+        @Test
+        @DisplayName("returns map covering inclusive range with checked days marked true and correct counts")
+        void statsHappyPath() {
+            LocalDate t = today();
+            LocalDate from = t.minusDays(6);
+            LocalDate to = t;
+
+            // Mark checkins on: t-6, t-4, t-1, t
+            List<Checkin> checkins = Arrays.asList(
+                    Checkin.builder().userId(userId).date(from).createdAt(Instant.now()).build(),
+                    Checkin.builder().userId(userId).date(from.plusDays(2)).createdAt(Instant.now()).build(),
+                    Checkin.builder().userId(userId).date(to.minusDays(1)).createdAt(Instant.now()).build(),
+                    Checkin.builder().userId(userId).date(to).createdAt(Instant.now()).build()
+            );
+            when(checkinRepository.findAllByUserIdAndDateBetweenOrderByDateAsc(userId, from, to)).thenReturn(checkins);
+
+            // For streak: today true, yesterday true, day before false => streak=2
+            when(checkinRepository.existsByUserIdAndDate(userId, to)).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, to.minusDays(1))).thenReturn(true);
+            when(checkinRepository.existsByUserIdAndDate(userId, to.minusDays(2))).thenReturn(false);
+
+            CheckinStatsResponse res = service.getStats(userId, from, to);
+
+            assertThat(res).isNotNull();
+            assertThat(res.totalDays()).isEqualTo(7);
+            assertThat(res.checkedDays()).isEqualTo(4);
+            assertThat(res.streak()).isEqualTo(2);
+            Map<LocalDate, Boolean> map = res.calendar();
+            assertThat(map).hasSize(7);
+            assertThat(map.get(from)).isTrue();
+            assertThat(map.get(from.plusDays(1))).isFalse();
+            assertThat(map.get(from.plusDays(2))).isTrue();
+            assertThat(map.get(to.minusDays(1))).isTrue();
+            assertThat(map.get(to)).isTrue();
+        }
+
+        @Test
+        @DisplayName("handles empty range (from > to) gracefully with zero counts and empty map")
+        void emptyRange() {
+            LocalDate t = today();
+            LocalDate from = t.plusDays(1);
+            LocalDate to = t.minusDays(1);
+
+            when(checkinRepository.findAllByUserIdAndDateBetweenOrderByDateAsc(userId, from, to))
+                    .thenReturn(Collections.emptyList());
+            // Streak still computed based on today (assume no checkin today)
+            when(checkinRepository.existsByUserIdAndDate(userId, t)).thenReturn(false);
+
+            CheckinStatsResponse res = service.getStats(userId, from, to);
+
+            assertThat(res.totalDays()).isEqualTo(0);
+            assertThat(res.checkedDays()).isEqualTo(0);
+            assertThat(res.calendar()).isEmpty();
+            assertThat(res.streak()).isEqualTo(0);
+        }
+    }
+}


### PR DESCRIPTION
📌 작업 내용
• 출석(체크인) 기능
　- 오늘 상태 조회(GET /checkins/today) / 출석 생성(idempotent, POST /checkins)
　- 기간 통계(GET /checkins/stats) / 월 통계(GET /checkins/stats/month?month=YYYY-MM)
　- 연속 출석계산

• 주간 요약 스케줄러
　- 매주 월요일 09:00 KST 실행, 지난주(월~일) 출석 집계
　- 중복 발송 방지(weekly_summaries 유니크
　- 대상만 인앱 알림(로그 기반 더미 발송)

• 채팅 세션/메시지 MVP
　- 세션 생성/목록: POST /sessions, GET /sessions
　- 메시지 전송/조회: POST /sessions/{id}/messages, GET /sessions/{id}/messages
　- 최초 SYSTEM 프롬프트 자동 저장
　- 더미 어시스턴트로 즉시 응답(룰/템플릿) → 추후 LLM 어댑터 교체만 하면 됨

• 프로필 연동
　- 프로필 페이지에서 이번 달 출석 지표 노출 가능
　- 채팅 SYSTEM 프롬프트에 프로필 정보 주입

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces chat sessions: create a session, list your sessions, view history, and send messages with assistant replies. Includes pagination for long lists.
  - Adds daily check-ins: see today’s status, check in, and view stats (date range or monthly). Tracks streaks and totals.
  - Delivers automatic weekly summaries each Monday (KST) with in-app notifications highlighting last week’s check-in progress.
- Security
  - Enables authenticated access to new chat and check-in endpoints for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->